### PR TITLE
fix(ci): resolve restricted actors from workflow policy

### DIFF
--- a/.github/workflows/automatic-pr-labeler.yaml
+++ b/.github/workflows/automatic-pr-labeler.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   assign-labels:
     name: "Assign Labels to PR #${{ github.event.pull_request.number }}"
-    if: (github.event.pull_request.merged == false) && (github.event.pull_request.user.login != 'dependabot[bot]') && (github.event.pull_request.user.login != 'github-actions[bot]')
+    if: github.event.pull_request.merged == false
     permissions:
       pull-requests: write
       contents: read
@@ -32,8 +32,38 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve workflow policy
+        id: policy
+        uses: netcracker/qubership-workflow-hub/actions/config-resolver@86c8965947f83325e558d72c5d9e0a5cde99ee21 # PR #866 (unreleased)
+        with:
+          file-path: .qubership/workflow-policy.json
+          schema: workflow-policy/v1
+
+      - name: Validate workflow policy
+        env:
+          CONFIG_JSON: ${{ steps.policy.outputs.config }}
+        run: |
+          jq -e '
+            def valid_actors:
+              type == "array"
+              and length > 0
+              and all(.[];
+                type == "object"
+                and (keys == ["id", "login"])
+                and (.id | type == "string" and test("^[0-9]+$"))
+                and (.login | type == "string" and length > 0))
+              and (map(.id) | length == (unique | length))
+              and (map(.login) | length == (unique | length));
+            type == "object"
+            and .schema == "workflow-policy/v1"
+            and (."no-publish-actors" | valid_actors)
+            and (."skip-pr-automation-actors" | valid_actors)
+            and ((keys - ["schema", "no-publish-actors", "skip-pr-automation-actors"]) | length == 0)
+          ' <<< "$CONFIG_JSON" > /dev/null
+
       - name: "Execute assign labels"
         id: action-assign-labels
+        if: ${{ !contains(fromJSON(steps.policy.outputs.config)['skip-pr-automation-actors'].*.id, format('{0}', github.event.pull_request.user.id)) }}
         uses: mauroalderete/action-assign-labels@671a4ca2da0f900464c58b8b5540a1e07133e915 # v1.5.1
         with:
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dev-docker-build.yaml
+++ b/.github/workflows/dev-docker-build.yaml
@@ -57,6 +57,8 @@ jobs:
       packages: read
     outputs:
       packages: ${{ steps.config.outputs.config }}
+      # Bot branches must build without publishing; merged code on the default branch follows normal publication.
+      force-dry-run: ${{ contains(fromJSON(steps.policy.outputs.config)['no-publish-actors'].*.id, format('{0}', github.actor_id)) && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -68,6 +70,35 @@ jobs:
         id: config
         with:
           file-path: "${{ env.CONFIG_FILE }}"
+
+      - name: Resolve workflow policy
+        id: policy
+        uses: netcracker/qubership-workflow-hub/actions/config-resolver@86c8965947f83325e558d72c5d9e0a5cde99ee21 # PR #866 (unreleased)
+        with:
+          file-path: .qubership/workflow-policy.json
+          schema: workflow-policy/v1
+
+      - name: Validate workflow policy
+        env:
+          CONFIG_JSON: ${{ steps.policy.outputs.config }}
+        run: |
+          jq -e '
+            def valid_actors:
+              type == "array"
+              and length > 0
+              and all(.[];
+                type == "object"
+                and (keys == ["id", "login"])
+                and (.id | type == "string" and test("^[0-9]+$"))
+                and (.login | type == "string" and length > 0))
+              and (map(.id) | length == (unique | length))
+              and (map(.login) | length == (unique | length));
+            type == "object"
+            and .schema == "workflow-policy/v1"
+            and (."no-publish-actors" | valid_actors)
+            and (."skip-pr-automation-actors" | valid_actors)
+            and ((keys - ["schema", "no-publish-actors", "skip-pr-automation-actors"]) | length == 0)
+          ' <<< "$CONFIG_JSON" > /dev/null
 
   docker-build:
     name: "Build and Publish Docker Image"
@@ -120,6 +151,6 @@ jobs:
           platforms: ${{ matrix.component.platforms }}
           checkout: "false"
           tags: ${{ steps.prepare_tags.outputs.tags }}
-          dry-run: ${{ github.event.inputs.dry-run || github.actor == 'renovate[bot]' || 'false' }}
+          dry-run: ${{ inputs.dry-run || needs.load-config.outputs.force-dry-run == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/profanity-filter.yaml
+++ b/.github/workflows/profanity-filter.yaml
@@ -9,18 +9,53 @@ on:
   pull_request:
     types: [opened, edited, reopened]
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   apply-filter:
     name: "Apply Profanity Filter"
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: Resolve workflow policy
+      id: policy
+      uses: netcracker/qubership-workflow-hub/actions/config-resolver@86c8965947f83325e558d72c5d9e0a5cde99ee21 # PR #866 (unreleased)
+      with:
+        file-path: .qubership/workflow-policy.json
+        schema: workflow-policy/v1
+
+    - name: Validate workflow policy
+      env:
+        CONFIG_JSON: ${{ steps.policy.outputs.config }}
+      run: |
+        jq -e '
+          def valid_actors:
+            type == "array"
+            and length > 0
+            and all(.[];
+              type == "object"
+              and (keys == ["id", "login"])
+              and (.id | type == "string" and test("^[0-9]+$"))
+              and (.login | type == "string" and length > 0))
+            and (map(.id) | length == (unique | length))
+            and (map(.login) | length == (unique | length));
+          type == "object"
+          and .schema == "workflow-policy/v1"
+          and (."no-publish-actors" | valid_actors)
+          and (."skip-pr-automation-actors" | valid_actors)
+          and ((keys - ["schema", "no-publish-actors", "skip-pr-automation-actors"]) | length == 0)
+        ' <<< "$CONFIG_JSON" > /dev/null
+
     - name: Scan issue or pull request for profanity
-      # Conditionally run the step if the actor isn't a bot
-      if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+      if: ${{ !contains(fromJSON(steps.policy.outputs.config)['skip-pr-automation-actors'].*.id, format('{0}', github.actor_id)) }}
       uses: IEvangelist/profanity-filter@4655e7a15cd4a13a5c9b13affed04a487f556083 # 13.4.0
       id: profanity-filter
       with:

--- a/.qubership/workflow-policy.json
+++ b/.qubership/workflow-policy.json
@@ -1,0 +1,27 @@
+{
+  "schema": "workflow-policy/v1",
+  "no-publish-actors": [
+    {
+      "id": "29139614",
+      "login": "renovate[bot]"
+    },
+    {
+      "id": "49699333",
+      "login": "dependabot[bot]"
+    }
+  ],
+  "skip-pr-automation-actors": [
+    {
+      "id": "29139614",
+      "login": "renovate[bot]"
+    },
+    {
+      "id": "49699333",
+      "login": "dependabot[bot]"
+    },
+    {
+      "id": "41898282",
+      "login": "github-actions[bot]"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Dependency bots must run Docker builds without receiving image publication behavior. Existing workflow conditions identify
bots by mutable login names and do not provide a shared policy for other PR automation.

## What

- Define operation-specific restricted actor records with immutable GitHub user IDs and readable login names.
- Load the policy through the schema-aware `config-resolver` from `qubership-workflow-hub`.
- Validate the complete policy before using it, so malformed configuration fails closed.
- Force Docker dry-run mode for Renovate and Dependabot outside the default branch.
- Allow normal publication after dependency updates are merged into the default branch.
- Skip Automatic PR Labeler and Profanity Filter for the configured automation accounts.
- Keep organization-owned bots unrestricted unless their IDs are explicitly listed.

CLA Assistant is unchanged because its existing `allowlist: ... ,bot*` uses the action's documented bot exclusion.

## How to verify

- Repository pre-commit hooks pass.
- `actionlint` passes for the three changed workflows, excluding pre-existing `SC2086` findings.
- Policy validation accepts the repository policy and rejects missing fields, non-string IDs, duplicate IDs or login
  names, malformed actor records, and unknown fields.
- An isolated `act` run executes the pinned `config-resolver` and policy validation successfully.
- Independent security review verified the actor identities and fail-closed behavior. It also found a
  `workflow_dispatch` string-boolean issue, which this revision fixes by using the typed `inputs.dry-run` context.

## Follow-up

- `config-resolver` is pinned to the immutable merge commit of
  [workflow-hub#866](https://github.com/Netcracker/qubership-workflow-hub/pull/866) because it is not in a tagged release.
- `workflow-hub/actions/verify-json` cannot replace the inline validation until its shell syntax and output mapping are
  fixed.
- The existing `docker-action@v2.4.0` still logs in to GHCR in dry-run mode, although `push: false` prevents image
  publication. Credential isolation requires a separate action or job-structure change.
